### PR TITLE
added linux build

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -1,0 +1,22 @@
+name: Linux Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2.3.4
+      with:
+        submodules: 'recursive'
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v2.13.2
+      with:
+        version: 5.15.2
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        qmake ..
+        make -j2


### PR DESCRIPTION
I know this is a really small PR, I was familiar with QMAKE last year but not now.

The Linux deployment is much more complicated than what normal people think: see [how Qv2ray deals with old distributions](https://github.com/Qv2ray/Qv2ray/blob/dev/.github/workflows/build-qv2ray-cmake.yml#L171)

I'd suggest not including Linux in the releases. instead, let users build themselves.

This PR adds a basic build on Linux just to make sure it builds, no installation steps are involved.